### PR TITLE
Add documentation for rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # CodeReviewTool
+
+A .NET rule engine for validating Blue Prism process files.
+
+See [docs/rules.md](docs/rules.md) for details on the rule configuration format and evaluator behavior.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,60 @@
+# Rules Configuration
+
+The `rulesConfig.json` file defines how the `RulesEngine` validates a process. Rules are organized into **rule groups** under the `RuleGroups` section. Each group contains a `Rules` object mapping a rule ID to its properties.
+
+Example structure:
+
+```json
+{
+  "RuleGroups": {
+    "Variables": {
+      "Rules": {
+        "VAR-001": { "Description": "..." }
+      }
+    },
+    "Pages": { "Rules": { "PAGE-001": { } } }
+  }
+}
+```
+
+The classes `RuleConfig` and `RuleGroup` in `RulesEngine/RuleConfig.cs` represent this layout in code.
+
+## Variables
+
+Rules in the **Variables** group validate naming and placement of variables. Common fields include:
+
+- `Description` – explains what the rule checks.
+- `Characters`, `Prefixes`, `Suffixes` – lists used to build naming conventions.
+- `MultiwordDelimited`, `HungarianNotation` – allowed casing or notation styles.
+- `Start Stage Allowed Prefixes`, `End Stage Allowed Prefixes` – restrict where variables can be declared.
+- `Length` – maximum allowed variable length (VAR‑004).
+- `Error Message` – text shown when validation fails. Placeholders such as `{NAMEOFVAR}` or `{EXPECTEDPREFIXES}` are replaced at runtime.
+- `Active` – set to `true` to enable the rule.
+
+### Adding a new variable rule
+
+Add a new rule ID under `Variables -> Rules` in `rulesConfig.json`:
+
+```json
+"VAR-006": {
+  "Description": "Checks variable placement within color-coded blocks.",
+  "Environment Variables Color": { "Name": "Environment", "Color": "Blue" },
+  "Error Message": "Variable '{NAMEOFVAR}' is not inside the correct block.",
+  "Active": true
+}
+```
+
+Implement the corresponding method (e.g. `EvaluateVar006`) in `GeneralRuleEvaluator`. The engine loads new rules with `AddRulesFromConfig()` and applies them when `ValidateAll()` is called.
+
+## Pages
+
+The **Pages** group contains rules that operate on page contexts. Fields include:
+
+- `Description` – summary of the rule.
+- `Count` – maximum number of pages allowed (PAGE‑001).
+- `Word Count` – minimum description length (PAGE‑002).
+- `Error Message` and `Active` – behave the same as in the Variables group.
+
+## Evaluator behavior
+
+When `ValidateAll()` runs, each active rule is evaluated against the appropriate context. `GeneralRuleEvaluator` selects a method based on the rule ID (e.g. `EvaluateVar001`, `EvaluatePage001`). Custom evaluators can be registered with `RulesEngine.RegisterEvaluator` if needed.


### PR DESCRIPTION
## Summary
- add link to new rules documentation in README
- document rule configuration in docs/rules.md

## Testing
- `dotnet build CodeReviewTool.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc77a88083259ad507a93cf83743