### PR TITLE
Improve error handling for file loading

### DIFF
--- a/CodeReviewTool/Program.cs
+++ b/CodeReviewTool/Program.cs
@@ -21,9 +21,27 @@ namespace CodeReviewTool
         static void Main(string[] args)
         {
             var engine = new RulesEngine.RulesEngine();
-            engine.LoadRuleConfig("rulesConfig.json");
-            engine.AddRulesFromConfig();
-            engine.Initialize(@"C:\Users\Xolan\Downloads\Processes\BPA Process - RBBAT10SS_Process Card and Card Blocks and Holds Closures.bpprocess");
+            try
+            {
+                engine.LoadRuleConfig("rulesConfig.json");
+                engine.AddRulesFromConfig();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to load rule configuration: {ex.Message}");
+                return;
+            }
+
+            try
+            {
+                engine.Initialize(@"C:\Users\Xolan\Downloads\Processes\BPA Process - RBBAT10SS_Process Card and Card Blocks and Holds Closures.bpprocess");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to load process file: {ex.Message}");
+                return;
+            }
+
             engine.ValidateAll();
 
             // Load the XML content

--- a/RulesEngine/RulesEngine.cs
+++ b/RulesEngine/RulesEngine.cs
@@ -22,8 +22,16 @@ namespace RulesEngine
         public void Initialize(string path)
         {
             this.path = path;
-            this.xmlContent = XElement.Load(path);
-            contexts.LoadContexts(this.xmlContent);
+            try
+            {
+                this.xmlContent = XElement.Load(path);
+                contexts.LoadContexts(this.xmlContent);
+            }
+            catch (Exception ex) when (ex is IOException || ex is System.Xml.XmlException)
+            {
+                Console.WriteLine($"Could not load process file '{path}': {ex.Message}");
+                throw;
+            }
         }
 
         public void RegisterEvaluator(string ruleId, IRuleEvaluator evaluator)
@@ -39,8 +47,16 @@ namespace RulesEngine
 
         public RuleConfig LoadRuleConfig(string filePath)
         {
-            var jsonString = File.ReadAllText(filePath);
-            ruleConfig = JsonConvert.DeserializeObject<RuleConfig>(jsonString);
+            try
+            {
+                var jsonString = File.ReadAllText(filePath);
+                ruleConfig = JsonConvert.DeserializeObject<RuleConfig>(jsonString);
+            }
+            catch (Exception ex) when (ex is IOException || ex is JsonException)
+            {
+                Console.WriteLine($"Could not load rule configuration '{filePath}': {ex.Message}");
+                throw;
+            }
 
             // Manual validation (optional based on your needs)
             if (ruleConfig?.RuleGroups == null || !ruleConfig.RuleGroups.Any())


### PR DESCRIPTION
## Summary
- catch IO and JSON errors when loading rules or processes
- show friendly error messages if configuration or process files cannot be loaded
- wrap calls in Program.cs with try-catch to exit gracefully

## Testing
- `dotnet build CodeReviewTool.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc6c01ec8325bd6623901a63e9f7