### PR TITLE
Add PAGE-003 rule to configuration

### DIFF
--- a/CodeReviewTool/rulesConfig.json
+++ b/CodeReviewTool/rulesConfig.json
@@ -61,6 +61,13 @@
           "Word Count": 15,
           "Error Message": "The minimum number of words in the description box required are {WORDCOUNT}",
           "Active": true
+        },
+
+        "PAGE-003": {
+          "Description": "Validates that preconditions and postconditions contain a minimum amount of detail.",
+          "Word Count": 10,
+          "Error Message": "Preconditions or postconditions for page '{PAGENAME}' must contain at least {WORDCOUNT} words. Current counts are {PREACTUALWORDCOUNT} and {POSTACTUALWORDCOUNT}.",
+          "Active": true
         }
       }
 


### PR DESCRIPTION
## Summary
- extend rule config with PAGE-003 entry
- PAGE-003 already routed to `EvaluatePage003`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ffb839688325b497568df74cee62