### PR TITLE
Add VAR-007 whitespace rule

### DIFF
--- a/CodeReviewTool/rulesConfig.json
+++ b/CodeReviewTool/rulesConfig.json
@@ -42,6 +42,12 @@
           "End Stage Allowed Prefixes": [ "out", "gout" ],
           "Error Message": "Variable '{NAMEOFVAR}', with prefix '{PREFIX}', must be declared within {EXPECTEDSTAGES} stages to align with its lifecycle.",
           "Active": true
+        },
+
+        "VAR-007": {
+          "Description": "Variable names should not contain whitespace characters.",
+          "Error Message": "Variable '{NAMEOFVAR}' contains whitespace, which is not allowed.",
+          "Active": true
         }
 
       }

--- a/RulesEngine/GeneralRuleEvaluator.cs
+++ b/RulesEngine/GeneralRuleEvaluator.cs
@@ -49,6 +49,8 @@ namespace RulesEngine
                     return EvaluateVar005(ruleProperties, stageContext);
                 case "VAR-006":
                     return EvaluateVar006(ruleProperties, stageContext, additionalprops);
+                case "VAR-007":
+                    return EvaluateVar007(ruleProperties, stageContext);
 
                 // Add cases for other VAR-XXX as needed
                 default:
@@ -345,6 +347,21 @@ namespace RulesEngine
                 return false;
             }
 
+
+            return true;
+        }
+
+        private bool EvaluateVar007(Dictionary<string, object> properties, StageContext context)
+        {
+            var variableName = context.Name;
+            var errorMessageTemplate = properties["Error Message"].ToString();
+
+            if (!string.IsNullOrEmpty(variableName) && variableName.Any(char.IsWhiteSpace))
+            {
+                string errorMessage = errorMessageTemplate.Replace("{NAMEOFVAR}", variableName);
+                Console.WriteLine(errorMessage);
+                return false;
+            }
 
             return true;
         }


### PR DESCRIPTION
## Summary
- implement VAR-007 evaluator that flags whitespace in variable names
- register VAR-007 in GeneralRuleEvaluator
- extend `rulesConfig.json` with the new rule

## Testing
- `dotnet build CodeReviewTool.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ffccfe308325aceeca097395afe3