### PR TITLE
Add web API for external integration

### DIFF
--- a/CodeReviewTool.Api/CodeReviewTool.Api.csproj
+++ b/CodeReviewTool.Api/CodeReviewTool.Api.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RulesEngine\RulesEngine.csproj" />
+  </ItemGroup>
+</Project>

--- a/CodeReviewTool.Api/Program.cs
+++ b/CodeReviewTool.Api/Program.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using RulesEngine;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<RulesEngine.RulesEngine>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapPost("/api/validate", async (HttpRequest request, RulesEngine.RulesEngine engine) =>
+{
+    if (!request.HasFormContentType)
+    {
+        return Results.BadRequest("Expected multipart/form-data");
+    }
+
+    var file = request.Form.Files["process"];
+    if (file == null)
+    {
+        return Results.BadRequest("Process file not provided");
+    }
+
+    var tempPath = Path.GetTempFileName();
+    using (var stream = File.Create(tempPath))
+    {
+        await file.CopyToAsync(stream);
+    }
+
+    engine.LoadRuleConfig("rulesConfig.json");
+    engine.AddRulesFromConfig();
+    engine.Initialize(tempPath);
+
+    var results = engine.ValidateAllWithResults();
+    File.Delete(tempPath);
+    return Results.Json(results);
+});
+
+app.Run();

--- a/CodeReviewTool.sln
+++ b/CodeReviewTool.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeReviewTool", "CodeRevie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RulesEngine", "RulesEngine\RulesEngine.csproj", "{E8A2E7A3-7B66-4A2F-A5A9-86EAA7A127C1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeReviewTool.Api", "CodeReviewTool.Api\CodeReviewTool.Api.csproj", "{BDB98BA0-E242-4006-85C3-9AA12412F7B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,8 +22,12 @@ Global
 		{E8A2E7A3-7B66-4A2F-A5A9-86EAA7A127C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E8A2E7A3-7B66-4A2F-A5A9-86EAA7A127C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E8A2E7A3-7B66-4A2F-A5A9-86EAA7A127C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E8A2E7A3-7B66-4A2F-A5A9-86EAA7A127C1}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {E8A2E7A3-7B66-4A2F-A5A9-86EAA7A127C1}.Release|Any CPU.Build.0 = Release|Any CPU
+                {BDB98BA0-E242-4006-85C3-9AA12412F7B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {BDB98BA0-E242-4006-85C3-9AA12412F7B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {BDB98BA0-E242-4006-85C3-9AA12412F7B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {BDB98BA0-E242-4006-85C3-9AA12412F7B8}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 A .NET rule engine for validating Blue Prism process files.
 
 See [docs/rules.md](docs/rules.md) for details on the rule configuration format and evaluator behavior.
+
+## API usage
+
+Run the `CodeReviewTool.Api` project to expose a REST endpoint for validating
+Blue Prism `.bpprocess` files. The service provides a single endpoint:
+
+```
+POST /api/validate
+```
+
+Upload the process file as multipart/form-data using the field name `process`.
+The response is a JSON array of validation messages.


### PR DESCRIPTION
## Summary
- add minimal ASP.NET API project
- expose `/api/validate` endpoint to run the rules engine on an uploaded `.bpprocess` file
- return validation messages for each rule
- update RulesEngine with helper method to capture results
- document API usage in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440055a1e483258c5f22335eb95713