### PR TITLE
Extend rules engine with security and logic checks

### DIFF
--- a/CodeReviewTool/rulesConfig.json
+++ b/CodeReviewTool/rulesConfig.json
@@ -103,6 +103,43 @@
           "Active": true
         }
       }
-    }
+    },
+    "Security": {
+      "Rules": {
+        "SEC-001": {
+          "Description": "Sensitive data items must be private and should not have hard-coded values.",
+          "Error Message": "Sensitive variable {NAMEOFVAR} should be private and not contain a value.",
+          "Active": true
+        },
+        "SEC-002": {
+          "Description": "Environment variables containing secrets must be marked private.",
+          "Error Message": "Environment variable {NAMEOFVAR} appears sensitive but is not private.",
+          "Active": true
+        }
+      }
+    },
+    "Environment": {
+      "Rules": {
+        "ENV-001": {
+          "Description": "Data items should not contain absolute file paths.",
+          "Error Message": "Data item {NAMEOFVAR} contains an absolute file path.",
+          "Active": true
+        }
+      }
+    },
+    "Logic": {
+      "Rules": {
+        "LOG-001": {
+          "Description": "Action stages should be inside a block for proper error handling.",
+          "Error Message": "Action stage {STAGENAME} is not inside a Block stage.",
+          "Active": true
+        },
+        "LOG-002": {
+          "Description": "Stage names should not contain common spelling mistakes.",
+          "Error Message": "Stage name {STAGENAME} contains spelling errors.",
+          "Active": true
+        }
+      }
+    },
   }
 }

--- a/RulesEngine.Tests/GeneralRuleEvaluatorTests.cs
+++ b/RulesEngine.Tests/GeneralRuleEvaluatorTests.cs
@@ -41,4 +41,44 @@ public class GeneralRuleEvaluatorTests
 
         Assert.False(result);
     }
+
+    private Dictionary<string, object> BuildSec001Properties()
+    {
+        return new Dictionary<string, object>
+        {
+            {"Error Message", "msg"}
+        };
+    }
+
+    [Fact]
+    public void EvaluateSec001_PublicPassword_ReturnsFalse()
+    {
+        var evaluator = new GeneralRuleEvaluator();
+        var props = BuildSec001Properties();
+        var context = new StageContext { Type = "Data", Name = "Password", Datatype = "password", Private = false, InitialValue = "123" };
+
+        var result = evaluator.Evaluate("SEC-001", props, context, null);
+
+        Assert.False(result);
+    }
+
+    private Dictionary<string, object> BuildEnv001Properties()
+    {
+        return new Dictionary<string, object>
+        {
+            {"Error Message", "msg"}
+        };
+    }
+
+    [Fact]
+    public void EvaluateEnv001_AbsolutePath_ReturnsFalse()
+    {
+        var evaluator = new GeneralRuleEvaluator();
+        var props = BuildEnv001Properties();
+        var context = new StageContext { Type = "Data", Name = "File", InitialValue = "C:\\temp\\file.txt" };
+
+        var result = evaluator.Evaluate("ENV-001", props, context, null);
+
+        Assert.False(result);
+    }
 }

--- a/RulesEngine/GeneralRuleEvaluator.cs
+++ b/RulesEngine/GeneralRuleEvaluator.cs
@@ -52,6 +52,17 @@ namespace RulesEngine
                 case "VAR-007":
                     return EvaluateVar007(ruleProperties, stageContext);
 
+                case "SEC-001":
+                    return EvaluateSec001(ruleProperties, stageContext);
+                case "SEC-002":
+                    return EvaluateSec002(ruleProperties, stageContext);
+                case "ENV-001":
+                    return EvaluateEnv001(ruleProperties, stageContext);
+                case "LOG-001":
+                    return EvaluateLog001(ruleProperties, stageContext, additionalprops);
+                case "LOG-002":
+                    return EvaluateLog002(ruleProperties, stageContext);
+
                 case "STAGE-001":
                     return EvaluateStage001(ruleProperties, stageContext);
                 case "STAGE-002":
@@ -365,6 +376,112 @@ namespace RulesEngine
             {
                 string errorMessage = errorMessageTemplate.Replace("{NAMEOFVAR}", variableName);
                 Console.WriteLine(errorMessage);
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool EvaluateSec001(Dictionary<string, object> properties, StageContext context)
+        {
+            if (!string.Equals(context.Type, "Data", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            bool sensitiveName = context.Name != null &&
+                (context.Name.ToLower().Contains("password") ||
+                 context.Name.ToLower().Contains("username") ||
+                 context.Name.ToLower().Contains("key"));
+
+            if ((context.Datatype != null && context.Datatype.Equals("password", StringComparison.OrdinalIgnoreCase)) || sensitiveName)
+            {
+                if (!string.IsNullOrEmpty(context.InitialValue) || context.Private != true)
+                {
+                    string msg = properties["Error Message"].ToString().Replace("{NAMEOFVAR}", context.Name);
+                    Console.WriteLine(msg);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool EvaluateSec002(Dictionary<string, object> properties, StageContext context)
+        {
+            if (!string.Equals(context.Type, "Data", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(context.Exposure, "Environment", StringComparison.OrdinalIgnoreCase))
+            {
+                var name = context.Name?.ToLower() ?? string.Empty;
+                if ((name.Contains("password") || name.Contains("key") || name.Contains("username")) && context.Private != true)
+                {
+                    string msg = properties["Error Message"].ToString().Replace("{NAMEOFVAR}", context.Name);
+                    Console.WriteLine(msg);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool EvaluateEnv001(Dictionary<string, object> properties, StageContext context)
+        {
+            if (!string.Equals(context.Type, "Data", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var value = context.InitialValue ?? string.Empty;
+            bool isAbsolute = value.StartsWith("\\\\") || System.Text.RegularExpressions.Regex.IsMatch(value, @"^[A-Za-z]:\\");
+            if (isAbsolute)
+            {
+                string msg = properties["Error Message"].ToString().Replace("{NAMEOFVAR}", context.Name);
+                Console.WriteLine(msg);
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool EvaluateLog001(Dictionary<string, object> properties, StageContext context, Dictionary<string, object>? additionalProps)
+        {
+            if (!string.Equals(context.Type, "Action", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (additionalProps == null || !additionalProps.TryGetValue("Blocks", out var blocksObj) || blocksObj is not List<StageContext> blocks)
+            {
+                return true;
+            }
+
+            bool inside = blocks.Any(b => IsContextWithinBlock(context, b));
+            if (!inside)
+            {
+                string msg = properties["Error Message"].ToString().Replace("{STAGENAME}", context.Name);
+                Console.WriteLine(msg);
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool EvaluateLog002(Dictionary<string, object> properties, StageContext context)
+        {
+            if (string.IsNullOrEmpty(context.Name))
+            {
+                return true;
+            }
+
+            var lower = context.Name.ToLower();
+            if (lower.Contains("recove") || lower.Contains("occurance"))
+            {
+                string msg = properties["Error Message"].ToString().Replace("{STAGENAME}", context.Name);
+                Console.WriteLine(msg);
                 return false;
             }
 

--- a/RulesEngine/RulesEngine.cs
+++ b/RulesEngine/RulesEngine.cs
@@ -231,7 +231,28 @@ namespace RulesEngine
 
                             
                             break;
-                            // Handle other groups as needed
+                        case "Security":
+                        case "Environment":
+                        case "Logic":
+                            var secContexts = contexts.GetContexts<StageContext>();
+                            if (ruleId == "LOG-001")
+                            {
+                                var blocks = secContexts.Where(s => s.Type.Equals("Block")).ToList();
+                                secContexts = secContexts.Where(s => s.Type.Equals("Action")).ToList();
+                                additionalProperties.Add("Blocks", blocks);
+                            }
+                            if (ruleId == "SEC-001" || ruleId == "SEC-002" || ruleId == "ENV-001")
+                            {
+                                secContexts = secContexts.Where(s => s.Type.Equals("Data") || s.Type.Equals("Action")).ToList();
+                            }
+
+                            foreach (var context in secContexts)
+                            {
+                                bool result = Evaluate(ruleId, context, additionalProperties);
+                                Console.WriteLine(result ? $"Validation passed for rule {ruleId}." : $"Validation failed for rule {ruleId}.");
+                            }
+                            break;
+                        // Handle other groups as needed
                     }
                 }
             }
@@ -316,6 +337,27 @@ namespace RulesEngine
                                     bool result = Evaluate(ruleId, context, additionalProperties);
                                     messages.Add(result ? $"Validation passed for rule {ruleId}." : $"Validation failed for rule {ruleId}.");
                                 }
+                            }
+                            break;
+                        case "Security":
+                        case "Environment":
+                        case "Logic":
+                            var secContexts = contexts.GetContexts<StageContext>();
+                            if (ruleId == "LOG-001")
+                            {
+                                var blocks = secContexts.Where(s => s.Type.Equals("Block")).ToList();
+                                secContexts = secContexts.Where(s => s.Type.Equals("Action")).ToList();
+                                additionalProperties.Add("Blocks", blocks);
+                            }
+                            if (ruleId == "SEC-001" || ruleId == "SEC-002" || ruleId == "ENV-001")
+                            {
+                                secContexts = secContexts.Where(s => s.Type.Equals("Data") || s.Type.Equals("Action")).ToList();
+                            }
+
+                            foreach (var context in secContexts)
+                            {
+                                bool result = Evaluate(ruleId, context, additionalProperties);
+                                messages.Add(result ? $"Validation passed for rule {ruleId}." : $"Validation failed for rule {ruleId}.");
                             }
                             break;
                     }


### PR DESCRIPTION
## Summary
- add new security, environment, and logic rule definitions
- implement evaluator methods for new rules
- support new rule groups in engine
- cover new logic with unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440b1df37483258a0e7e31081c9d92