### PR TITLE
Extend tool with target-specific configs

### DIFF
--- a/CodeReviewTool/Program.cs
+++ b/CodeReviewTool/Program.cs
@@ -1,29 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.IO;
-using System.Linq;
-using System.Text.Json;
-using System.Xml.Linq;
 using RulesEngine;
-
 
 namespace CodeReviewTool
 {
-
-    
-
-
     internal class Program
     {
-
-        
-
         static void Main(string[] args)
         {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: CodeReviewTool <target> <file> [rulesConfig]");
+                Console.WriteLine("Targets: BluePrism, Python");
+                return;
+            }
+
+            var target = args[0];
+            var file = args[1];
+            var configPath = args.Length > 2 ? args[2] : $"rulesConfig.{target.ToLower()}.json";
+
             var engine = new RulesEngine.RulesEngine();
             try
             {
-                engine.LoadRuleConfig("rulesConfig.json");
+                engine.LoadRuleConfig(configPath);
                 engine.AddRulesFromConfig();
             }
             catch (Exception ex)
@@ -34,35 +33,27 @@ namespace CodeReviewTool
 
             try
             {
-                engine.Initialize(@"C:\Users\Xolan\Downloads\Processes\BPA Process - RBBAT10SS_Process Card and Card Blocks and Holds Closures.bpprocess");
+                if (target.Equals("BluePrism", StringComparison.OrdinalIgnoreCase))
+                {
+                    engine.Initialize(file);
+                }
+                else if (target.Equals("Python", StringComparison.OrdinalIgnoreCase))
+                {
+                    engine.LoadPythonFile(file);
+                }
+                else
+                {
+                    Console.WriteLine($"Unsupported target: {target}");
+                    return;
+                }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Failed to load process file: {ex.Message}");
+                Console.WriteLine($"Failed to load input file: {ex.Message}");
                 return;
             }
 
             engine.ValidateAll();
-
-            // Load the XML content
-            //var xmlContent = XElement.Load(@"C:\Users\Xolan\Downloads\Processes\BPA Process - Variable Rules.bpprocess");
-
-            //var stageContexts = stageContext.ExtractStageContexts(xmlContent, "Data")
-            //.Where(s => !string.IsNullOrEmpty(s.Exposure))
-            //.ToList();
-
-            // Register the general rule evaluator
-            //engine.RegisterEvaluator(Rule.Id , new GeneralRuleEvaluator());
-
-            // Evaluate rules against contexts
-            /*foreach (var sContext in stageContexts)
-            {
-                // Adapt this to loop through all applicable rules instead of hardcoding "VAR-002"
-                bool result = engine.Evaluate("VAR-002", sContext);
-                //Console.WriteLine(result ? "Variable name is valid." : "Variable name is invalid.");
-            }*/
-
-            Console.ReadLine();
         }
     }
 }

--- a/CodeReviewTool/rulesConfig.blueprism.json
+++ b/CodeReviewTool/rulesConfig.blueprism.json
@@ -103,6 +103,42 @@
           "Active": true
         }
       }
-    }
+    },
+    "Security": {
+      "Rules": {
+        "SEC-001": {
+          "Description": "Sensitive data items must be private and should not have hard-coded values.",
+          "Error Message": "Sensitive variable {NAMEOFVAR} should be private and not contain a value.",
+          "Active": true
+        },
+        "SEC-002": {
+          "Description": "Environment variables containing secrets must be marked private.",
+          "Error Message": "Environment variable {NAMEOFVAR} appears sensitive but is not private.",
+          "Active": true
+        }
+      }
+    },
+    "Environment": {
+      "Rules": {
+        "ENV-001": {
+          "Description": "Data items should not contain absolute file paths.",
+          "Error Message": "Data item {NAMEOFVAR} contains an absolute file path.",
+          "Active": true
+        }
+      }
+    },
+    "Logic": {
+      "Rules": {
+        "LOG-001": {
+          "Description": "Action stages should be inside a block for proper error handling.",
+          "Error Message": "Action stage {STAGENAME} is not inside a Block stage.",
+          "Active": true
+        },
+        "LOG-002": {
+          "Description": "Stage names should not contain common spelling mistakes.",
+          "Error Message": "Stage name {STAGENAME} contains spelling errors.",
+          "Active": true
+        }
+      }
   }
 }

--- a/CodeReviewTool/rulesConfig.python.json
+++ b/CodeReviewTool/rulesConfig.python.json
@@ -1,0 +1,18 @@
+{
+  "RuleGroups": {
+    "Python": {
+      "Rules": {
+        "PY-001": {
+          "Description": "Avoid use of eval or exec in Python code.",
+          "Error Message": "File {FILEPATH} uses eval/exec which is insecure.",
+          "Active": true
+        },
+        "PY-002": {
+          "Description": "Do not leave TODO comments in code.",
+          "Error Message": "File {FILEPATH} contains TODO comments.",
+          "Active": true
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ Execute the following command from the repository root to run all tests:
 dotnet test
 ```
 
-A .NET rule engine for validating Blue Prism process files.
+## Command line usage
+Run the console with:
+```bash
+CodeReviewTool <target> <file> [rulesConfig]
+```
+The default rules configuration is `rulesConfig.<target>.json`. Targets supported: `BluePrism`, `Python`.
+
+
+A .NET rule engine for validating Blue Prism and Python code. Specify the target when running.
 
 See [docs/rules.md](docs/rules.md) for details on the rule configuration format and evaluator behavior.
 

--- a/RulesEngine.Tests/GeneralRuleEvaluatorTests.cs
+++ b/RulesEngine.Tests/GeneralRuleEvaluatorTests.cs
@@ -41,4 +41,84 @@ public class GeneralRuleEvaluatorTests
 
         Assert.False(result);
     }
+
+    private Dictionary<string, object> BuildSec001Properties()
+    {
+        return new Dictionary<string, object>
+        {
+            {"Error Message", "msg"}
+        };
+    }
+
+    [Fact]
+    public void EvaluateSec001_PublicPassword_ReturnsFalse()
+    {
+        var evaluator = new GeneralRuleEvaluator();
+        var props = BuildSec001Properties();
+        var context = new StageContext { Type = "Data", Name = "Password", Datatype = "password", Private = false, InitialValue = "123" };
+
+        var result = evaluator.Evaluate("SEC-001", props, context, null);
+
+        Assert.False(result);
+    }
+
+    private Dictionary<string, object> BuildEnv001Properties()
+    {
+        return new Dictionary<string, object>
+        {
+            {"Error Message", "msg"}
+        };
+    }
+
+    [Fact]
+    public void EvaluateEnv001_AbsolutePath_ReturnsFalse()
+    {
+        var evaluator = new GeneralRuleEvaluator();
+        var props = BuildEnv001Properties();
+        var context = new StageContext { Type = "Data", Name = "File", InitialValue = "C:\\temp\\file.txt" };
+
+        var result = evaluator.Evaluate("ENV-001", props, context, null);
+
+        Assert.False(result);
+    }
+
+    private Dictionary<string, object> BuildPy001Properties()
+    {
+        return new Dictionary<string, object>
+        {
+            {"Error Message", "msg"}
+        };
+    }
+
+    [Fact]
+    public void EvaluatePy001_EvalUsed_ReturnsFalse()
+    {
+        var evaluator = new GeneralRuleEvaluator();
+        var props = BuildPy001Properties();
+        var context = new PythonContext { FilePath = "test.py", Code = "eval('1+1')" };
+
+        var result = evaluator.Evaluate("PY-001", props, context, null);
+
+        Assert.False(result);
+    }
+
+    private Dictionary<string, object> BuildPy002Properties()
+    {
+        return new Dictionary<string, object>
+        {
+            {"Error Message", "msg"}
+        };
+    }
+
+    [Fact]
+    public void EvaluatePy002_TodoComment_ReturnsFalse()
+    {
+        var evaluator = new GeneralRuleEvaluator();
+        var props = BuildPy002Properties();
+        var context = new PythonContext { FilePath = "test.py", Code = "# TODO: fix" };
+
+        var result = evaluator.Evaluate("PY-002", props, context, null);
+
+        Assert.False(result);
+    }
 }

--- a/RulesEngine/contexts.cs
+++ b/RulesEngine/contexts.cs
@@ -303,4 +303,10 @@ namespace RulesEngine
 
     }
 
+    public class PythonContext : Contexts
+    {
+        public string FilePath { get; set; } = string.Empty;
+        public string Code { get; set; } = string.Empty;
+    }
+
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,6 +1,6 @@
 # Rules Configuration
 
-The `rulesConfig.json` file defines how the `RulesEngine` validates a process. Rules are organized into **rule groups** under the `RuleGroups` section. Each group contains a `Rules` object mapping a rule ID to its properties.
+The `rulesConfig.<target>.json` file (e.g., `rulesConfig.blueprism.json` or `rulesConfig.python.json`) defines how the `RulesEngine` validates a process. Rules are organized into **rule groups** under the `RuleGroups` section. Each group contains a `Rules` object mapping a rule ID to its properties.
 
 Example structure:
 
@@ -33,7 +33,7 @@ Rules in the **Variables** group validate naming and placement of variables. Com
 
 ### Adding a new variable rule
 
-Add a new rule ID under `Variables -> Rules` in `rulesConfig.json`:
+Add a new rule ID under `Variables -> Rules` in `rulesConfig.<target>.json`:
 
 ```json
 "VAR-006": {


### PR DESCRIPTION
## Summary
- separate rules into Blue Prism and Python configs
- add `rulesConfig.python.json` for Python checks
- update console and API to select target and config automatically
- document new command line usage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440b1df37483258a0e7e31081c9d92